### PR TITLE
[Fix] Return correct field name when using underscored: true

### DIFF
--- a/src/property.js
+++ b/src/property.js
@@ -32,7 +32,7 @@ class Property extends BaseProperty {
   }
 
   name() {
-    return this.sequelizePath.field
+    return this.sequelizePath.fieldName
   }
 
   isEditable() {

--- a/src/property.js
+++ b/src/property.js
@@ -27,7 +27,7 @@ const TYPES_MAPPING = [
 
 class Property extends BaseProperty {
   constructor(sequelizePath) {
-    super({ path: sequelizePath.field })
+    super({ path: sequelizePath.fieldName })
     this.sequelizePath = sequelizePath
   }
 


### PR DESCRIPTION
When using underscored: true, `sequelizeField.field` returns field name from database (i.e. first_name), but `sequelizeField.fieldName` returns correct name for underscored option in model (firstName), so every field name in model that differs from database name will not get returned when using SELECT and it is impossible to update or delete such a field.

Related PR:
https://github.com/SoftwareBrothers/admin-bro-sequelizejs/pull/24