### PR TITLE
Fixes errors with custom fieldNames

### DIFF
--- a/src/property.js
+++ b/src/property.js
@@ -27,12 +27,12 @@ const TYPES_MAPPING = [
 
 class Property extends BaseProperty {
   constructor(sequelizePath) {
-    super({ path: sequelizePath.field })
+    super({ path: sequelizePath.fieldName })
     this.sequelizePath = sequelizePath
   }
 
   name() {
-    return this.sequelizePath.field
+    return this.sequelizePath.fieldName
   }
 
   isEditable() {


### PR DESCRIPTION
When you use sequelize with a custom fieldName different from the backing field, all the records will faill to logging the error: 'You have to specify "recordId" for record action'.