### PR TITLE
Remove empty string from parsed params for more types

### DIFF
--- a/src/resource.js
+++ b/src/resource.js
@@ -179,8 +179,8 @@ class Resource extends BaseResource {
     const parsedParams = { ...params }
     this.properties().forEach((property) => {
       const value = parsedParams[property.name()]
-      if (['number', 'float', 'reference'].includes(property.type())) {
-        if (value === '') {
+      if (value === '') {
+        if (property.isArray() || property.type() !== 'string') {
           delete parsedParams[property.name()]
         }
       }


### PR DESCRIPTION
When a column has a non-string type and is nullable (like a nullable date), editing the resource will send an empty string to sequelize.  This fails validation for these columns.  

Rather than send an empty string, the empty strings are removed for all non-string types (rather than just number, float and reference)