### PR TITLE
Validation error unique

### DIFF
--- a/src/resource.js
+++ b/src/resource.js
@@ -8,6 +8,7 @@ const convertFilter = require('./utils/convert-filter')
 const createValidationError = require('./utils/create-validation-error')
 
 const SEQUELIZE_VALIDATION_ERROR = 'SequelizeValidationError'
+const SEQUELIZE_UNIQUE_ERROR = 'SequelizeUniqueConstraintError'
 
 class Resource extends BaseResource {
   static isAdapterFor(rawResource) {
@@ -134,6 +135,9 @@ class Resource extends BaseResource {
       if (error.name === SEQUELIZE_VALIDATION_ERROR) {
         throw createValidationError(error)
       }
+      if (error.name === SEQUELIZE_UNIQUE_ERROR) {
+        throw createValidationError(error)
+      }
       throw error
     }
   }
@@ -151,6 +155,9 @@ class Resource extends BaseResource {
       return record.toJSON()
     } catch (error) {
       if (error.name === SEQUELIZE_VALIDATION_ERROR) {
+        throw createValidationError(error)
+      }
+      if (error.name === SEQUELIZE_UNIQUE_ERROR) {
         throw createValidationError(error)
       }
       throw error


### PR DESCRIPTION
Fix #17 

Handle all [`ValidationError`](https://github.com/sequelize/sequelize/blob/e05351492ac535f7eff977e29041c4a2eb4ee0d6/src/errors/validation-error.ts) from sequelize and pass them back

This handles [`UniqueConstraintError`](https://github.com/sequelize/sequelize/blob/e05351492ac535f7eff977e29041c4a2eb4ee0d6/src/errors/validation/unique-constraint-error.ts#L17) as well, since it extends on `ValidationError`

