### PR TITLE
fix: filter convertion for string property

### DIFF
--- a/src/utils/convert-filter.ts
+++ b/src/utils/convert-filter.ts
@@ -1,6 +1,6 @@
 import escape from 'escape-regexp'
 import {
-  Op, where, fn, col,
+  Op,
 } from 'sequelize'
 
 const convertFilter = (filter) => {
@@ -20,11 +20,11 @@ const convertFilter = (filter) => {
       return {
         [Op.and]: [
           ...(memo[Op.and] || []),
-          where(
-            fn('LOWER', col(`${property.sequelizePath.Model.name}.${property.name()}`)), {
-              [Op.like as unknown as string]: fn('LOWER', `%${escape(value)}%`),
+          {
+            [`${property.name()}`]: {
+              [Op.iLike as unknown as string]: `%${escape(value)}%`,
             },
-          ),
+          },
         ],
         ...memo,
       }


### PR DESCRIPTION
(Fixes #52 )Fixed filter convertion. When filtering by string, it was failing with the following error:
```
Error: Invalid value Where {
  attribute: Fn { fn: 'LOWER', args: [ Col { col: 'users.nickname' } ] },
  comparator: '=',
  logic: { [Symbol(like)]: Fn { fn: 'LOWER', args: [ '%t%' ] } }
}
```