### PR TITLE
Fix string filter problem with multiple fields

### DIFF
--- a/src/utils/convert-filter.ts
+++ b/src/utils/convert-filter.ts
@@ -18,6 +18,7 @@ const convertFilter = (filter) => {
         }
       }
       return {
+        ...memo,
         [Op.and]: [
           ...(memo[Op.and] || []),
           {
@@ -25,8 +26,7 @@ const convertFilter = (filter) => {
               [Op.iLike as unknown as string]: `%${escape(value)}%`,
             },
           },
-        ],
-        ...memo,
+        ]
       }
     case 'number':
       if (!Number.isNaN(Number(value))) {

--- a/src/utils/convert-filter.ts
+++ b/src/utils/convert-filter.ts
@@ -26,7 +26,7 @@ const convertFilter = (filter) => {
               [Op.iLike as unknown as string]: `%${escape(value)}%`,
             },
           },
-        ]
+        ],
       }
     case 'number':
       if (!Number.isNaN(Number(value))) {


### PR DESCRIPTION
Fix the problem for: When applying more than one string field for filtering, only the first field works, the others just override by the first one. 