### PR TITLE
feat: allow to pass an array to filter

### DIFF
--- a/src/property.ts
+++ b/src/property.ts
@@ -80,7 +80,7 @@ class Property extends BaseProperty {
 
   availableValues(): Array<string> | null {
     return this.sequelizePath.values && this.sequelizePath.values.length
-      ? this.sequelizePath.values
+      ? this.sequelizePath.values as Array<string>
       : null
   }
 

--- a/src/utils/convert-filter.ts
+++ b/src/utils/convert-filter.ts
@@ -8,36 +8,64 @@ const convertFilter = (filter) => {
     return {}
   }
   return filter.reduce((memo, filterProperty) => {
-    const { property, value } = filterProperty
+    const { property, value, path: filterPath } = filterProperty
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, index] = filterPath.split('.')
+    const isArray = typeof index !== 'undefined' && !Number.isNaN(Number(index))
+    const previousValue = memo[property.name()] || {}
     switch (property.type()) {
-    case 'string':
+    case 'string': {
       if (property.sequelizePath.values) {
         return {
           [property.name()]: { [Op.eq]: `${escape(value)}` },
           ...memo,
         }
       }
+      if (isArray) {
+        return {
+          ...memo,
+          [property.name()]: {
+            [Op.in]: [
+              ...(previousValue[Op.in] || []),
+              escape(value),
+            ],
+          },
+        }
+      }
       return {
         [Op.and]: [
           ...(memo[Op.and] || []),
           {
-            [`${property.name()}`]: {
+            [property.name()]: {
               [Op.iLike as unknown as string]: `%${escape(value)}%`,
             },
           },
         ],
         ...memo,
       }
-    case 'number':
+    }
+    case 'number': {
       if (!Number.isNaN(Number(value))) {
+        if (isArray) {
+          return {
+            ...memo,
+            [property.name()]: {
+              [Op.in]: [
+                ...(previousValue[Op.in] || []),
+                Number(value),
+              ],
+            },
+          }
+        }
         return {
           [property.name()]: Number(value),
           ...memo,
         }
       }
       return memo
+    }
     case 'date':
-    case 'datetime':
+    case 'datetime': {
       if (value.from || value.to) {
         return {
           [property.name()]: {
@@ -48,8 +76,20 @@ const convertFilter = (filter) => {
         }
       }
       break
+    }
     default:
       break
+    }
+    if (isArray) {
+      return {
+        ...memo,
+        [property.name()]: {
+          [Op.in]: [
+            ...(previousValue[Op.in] || []),
+            value,
+          ],
+        },
+      }
     }
     return {
       [property.name()]: value,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,7 +2323,7 @@ babel-polyfill@6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-runtime@^6.11.6, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
+babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -2679,10 +2679,6 @@ chalk@^4.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
-
-chance@^1.0.4:
-  version "1.0.18"
-  resolved "https://registry.yarnpkg.com/chance/-/chance-1.0.18.tgz#79788fe6fca4c338bf404321c347eecc80f969ee"
 
 character-entities-html4@^1.0.0:
   version "1.1.4"
@@ -4073,13 +4069,6 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
-
-factory-girl@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/factory-girl/-/factory-girl-5.0.4.tgz#378caabe03aac7b327d47d9e28b4f02ced0c3c0b"
-  dependencies:
-    babel-runtime "^6.11.6"
-    chance "^1.0.4"
 
 fast-deep-equal@^3.1.1:
   version "3.1.1"
@@ -5997,7 +5986,7 @@ lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
-lodash@^4.17.14:
+lodash@^4.17.14, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -8654,15 +8643,15 @@ sequelize-pool@^6.0.0:
   resolved "https://registry.yarnpkg.com/sequelize-pool/-/sequelize-pool-6.1.0.tgz#caaa0c1e324d3c2c3a399fed2c7998970925d668"
   integrity sha512-4YwEw3ZgK/tY/so+GfnSgXkdwIJJ1I32uZJztIEgZeAO6HMgj64OzySbWLgxj+tXhZCJnzRfkY9gINw8Ft8ZMg==
 
-sequelize@^6.3.5:
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-6.3.5.tgz#80e3db7ac8b76d98c45ca93334197eb6e2335158"
-  integrity sha512-MiwiPkYSA8NWttRKAXdU9h0TxP6HAc1fl7qZmMO/VQqQOND83G4nZLXd0kWILtAoT9cxtZgFqeb/MPYgEeXwsw==
+sequelize@>4.42.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/sequelize/-/sequelize-6.4.0.tgz#02c7e06aa7371488c23f110cdd7e4c2666d92142"
+  integrity sha512-XiSAaYMidgLHgOFz0d0rMlSXP07YoL3GwuG0KTtXR6moR+lfdAA93vhLaN9K6f1ElLMutNTx2f7bNK6mACYfIA==
   dependencies:
     debug "^4.1.1"
     dottie "^2.0.0"
     inflection "1.12.0"
-    lodash "^4.17.15"
+    lodash "^4.17.20"
     moment "^2.26.0"
     moment-timezone "^0.5.31"
     retry-as-promised "^3.2.0"


### PR DESCRIPTION
This should let you do:

```
const before = (request) => {
  const { query } = request;
  const { filters = {} } = query;

  filters.someField = [1, 2, 3, 4];

  const newRequest = {
    ...request,
    query: {
      ...request.query: {
        filters
      }
    }
  };
  return newRequest;
}
```

and it will generate a `where someField in (1, 2, 3)` sql