### PR TITLE
fix: Model Instance Update should have hooks: true

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -181,7 +181,7 @@ class Resource extends BaseResource {
           [this.primaryKey()]: id,
         },
         individualHooks: true,
-        hooks: false,
+        hooks: true,
       });
       const record = await this.findById(id);
       return record.toJSON();


### PR DESCRIPTION
Currently if you have some getter in the model, sequelize will use that getter to set the value in the databse, because the option hooks in the `update` method of the model instance is set to `false`

This pull request correct this behaviour and sets that option to `true`

Fix: [https://github.com/SoftwareBrothers/adminjs/issues/1039](url)